### PR TITLE
[3] Bump up version of cli to 4.0.1

### DIFF
--- a/dev/src/commands/AbstractDockerCommand.ts
+++ b/dev/src/commands/AbstractDockerCommand.ts
@@ -20,7 +20,7 @@ export default abstract class AbstractDockerCommand {
 
     protected async checkDockerImage(docker: any): Promise<boolean> {
         return new Promise<boolean>(async function (resolve, reject)  {
-            var opts = {"filters": '{"reference": ["openapitools/openapi-generator-cli:v4.0.0"]}'};
+            var opts = {"filters": '{"reference": ["openapitools/openapi-generator-cli:v4.0.1"]}'};
             Log.i("Calling docker.listImages()");    
             await docker.listImages(opts, function(error: NodeJS.ErrnoException, addresses: string[]) {
                 Log.i("docker.listImages() error is " + error);
@@ -54,7 +54,7 @@ export default abstract class AbstractDockerCommand {
         });
         Log.i("Calling docker.pull() after authCheck: " + authCheck);
         return new Promise<boolean>(async function (resolve, reject) {
-            await docker.pull('openapitools/openapi-generator-cli:v4.0.0', async (error: any, streamo: any) => {
+            await docker.pull('openapitools/openapi-generator-cli:v4.0.1', async (error: any, streamo: any) => {
                 // Log the output of pull.
                 // streamo.on('data', (d: any) => {
                 //    Log.i(d.toString());

--- a/dev/src/commands/AbstractGenerateStubCommand.ts
+++ b/dev/src/commands/AbstractGenerateStubCommand.ts
@@ -176,7 +176,7 @@ export default abstract class AbstractGenerateStubCommand extends AbstractGenera
             var outStr = await this.enableProgressReporter(progress);
             Log.i("Mapped gen comamnd is " + 'generate -i /gen/' + this.selectedDefinition + ' -g ' + this.selectedGeneratorType + ' -o /out -v ' + this.fqPathToDefinition + ':/gen' + " -v " + this.fqPathOutputLocation +':/out');
             await docker.run(
-                "openapitools/openapi-generator-cli:v4.0.0",
+                "openapitools/openapi-generator-cli:v4.0.1",
                 ['generate', '-i', '/gen/' + this.selectedDefinition, '-g', this.selectedGeneratorType, '-o', '/out'],
                 outStr,
                 {Binds: [`${this.fqPathToDefinition}:/gen`, `${this.fqPathOutputLocation}:/out`]},

--- a/dev/src/commands/HtmlDocsCommand.ts
+++ b/dev/src/commands/HtmlDocsCommand.ts
@@ -57,7 +57,7 @@ export default class HtmlDocsCommand extends AbstractGenerateCommand {
 
             Log.i("Mapped gen comamnd is " + 'generate -i /gen/' + this.selectedDefinition + ' -g ' + 'html2' + ' -o /out -v ' + this.fqPathToDefinition + ':/gen' + " -v " + this.fqPathOutputLocation +':/out');
             await docker.run(
-                "openapitools/openapi-generator-cli:v4.0.0",
+                "openapitools/openapi-generator-cli:v4.0.1",
                 ['generate', '-i', '/gen/' + this.selectedDefinition, '-g', 'html2', '-o', '/out'],
                 outStr,
                 {Binds: [`${this.fqPathToDefinition}:/gen`, `${this.fqPathOutputLocation}:/out`]},


### PR DESCRIPTION
PR for https://github.com/eclipse/codewind-openapi-vscode/issues/3

Tested.  It pulled:

openapitools/openapi-generator-cli                                     v4.0.1