### PR TITLE
[8] Extension is missing a description

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "codewind-openapi-tools",
 	"displayName": "codewind-openapi-tools",
-	"description": "",
+	"description": "Create API clients, server stubs, and HTML documentation from OpenAPI Specifications",
 	"version": "0.2.0",
 	"publisher": "IBM",
 	"engines": {


### PR DESCRIPTION
[8] Extension is missing a description

PR for https://github.com/eclipse/codewind-openapi-vscode/issues/8

Signed-off-by: Keith Chong <kchong@ca.ibm.com>