### PR TITLE
[20] Don't limit openapi filename

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "codewind-openapi-tools",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,7 @@
 	"name": "codewind-openapi-tools",
 	"displayName": "Codewind OpenAPI Tools",
 	"description": "Create API clients, server stubs, and HTML documentation from OpenAPI Specifications",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "IBM",
 	"engines": {
 		"vscode": "^1.33.0"

--- a/dev/src/constants/Strings.json
+++ b/dev/src/constants/Strings.json
@@ -14,7 +14,7 @@
         "promptToPullImage": "The docker image, openapi-generator-cli, needs to be pulled from dockerhub. Continue?",
         "pullingImage": "Pulling image",
         "generatorRunning": "Generator running",
-        "errorNoDefinitions": "There are no OpenAPI Specifications (files named 'openapi' with the extension json or yaml) in the project.  Copy or import an OpenAPI Specification into the project."
+        "errorNoDefinitions": "There are no OpenAPI Specifications in the project.  Copy or import an OpenAPI Specification into the project."
     },
     "codeGen": {
         "success": "The {0} stub generated successfully",


### PR DESCRIPTION
Will now list any file that has the extension yaml, yml or json, but exclude specifically,

package.json
package-lock.json
chart.yaml
nodemon.json
manifest.yml
devfile.yaml

We can investigate adding content types later

Signed-off-by: Keith Chong <kchong@ca.ibm.com>