### PR TITLE
[34] Externalize package.json

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "codewind-openapi-tools",
-	"displayName": "Codewind OpenAPI Tools",
-	"description": "Create API clients, server stubs, and HTML documentation from OpenAPI Specifications",
-	"version": "0.2.1",
+	"displayName": "%displayName%",
+	"description": "%description%",
+	"version": "0.2.2",
 	"publisher": "IBM",
 	"engines": {
 		"vscode": "^1.33.0"
@@ -35,18 +35,18 @@
 		"commands": [
 			{
 				"command": "codewind.openapi-generate-client",
-				"title": "Generate Client from OpenAPI Specification",
-				"category": "OpenAPI"
+				"title": "%generateClient%",
+				"category": "%category%"
 			},
 			{
 				"command": "codewind.openapi-generate-server",
-				"title": "Generate Server from OpenAPI Specification",
-				"category": "OpenAPI"
+				"title": "%generateServer%",
+				"category": "%category%"
 			},
 			{
 				"command": "codewind.openapi-generate-html2",
-				"title": "Generate HTML from OpenAPI Specification",
-				"category": "OpenAPI"
+				"title": "%generateHtml%",
+				"category": "%category%"
 			}
 		],
 		"menus": {

--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -1,0 +1,8 @@
+{
+    "displayName": "Codewind OpenAPI Tools",
+    "description": "Create API clients, server stubs, and HTML documentation from an OpenAPI definition",
+    "category": "OpenAPI",
+    "generateClient": "Generate Client from OpenAPI Definition",
+    "generateServer": "Generate Server from OpenAPI Definition",
+    "generateHtml": "Generate HTML from OpenAPI Definition"
+}

--- a/dev/src/constants/Strings.json
+++ b/dev/src/constants/Strings.json
@@ -1,7 +1,7 @@
 {
     "commands" : {
         "selectProject": "Select Docker volume-mountable project:",
-        "selectOpenApiDefinition": "Select an Open API Specification:",
+        "selectOpenApiDefinition": "Select an Open API Definition:",
         "selectPrimaryLanguage": "Select the primary language for this project:",
         "selectClientGenType" : "Select client generator type",
         "selectServerGenType" : "Select server generator type"
@@ -14,7 +14,7 @@
         "promptToPullImage": "The docker image, openapi-generator-cli, needs to be pulled from dockerhub. Continue?",
         "pullingImage": "Pulling image",
         "generatorRunning": "Generator running",
-        "errorNoDefinitions": "There are no OpenAPI Specifications in the project.  Copy or import an OpenAPI Specification into the project."
+        "errorNoDefinitions": "There are no OpenAPI definitions in the project.  Copy or import an OpenAPI definition into the project."
     },
     "codeGen": {
         "success": "The {0} stub generated successfully",


### PR DESCRIPTION
There are strings still needed to be pulled out for easier access/review.

Also, I wasn't using references to the OpenAPI file consistently.   It should be document or definition.

Signed-off-by: Keith Chong <kchong@ca.ibm.com>