### PR TITLE
[36] Bump up version to 0.3.0

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "codewind-openapi-tools",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,7 @@
 	"name": "codewind-openapi-tools",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"publisher": "IBM",
 	"engines": {
 		"vscode": "^1.33.0"


### PR DESCRIPTION
Bump up version to 0.3.0

PR for https://github.com/eclipse/codewind-openapi-vscode/issues/36

Signed-off-by: Keith Chong <kchong@ca.ibm.com>