### PR TITLE
Add Build date info to 'build_info.properties' 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ spec:
                         cp $OUTPUT_NAME-*.vsix $OUTPUT_NAME.vsix
                         scp $OUTPUT_NAME.vsix $sshHost:$deployParentDir/$GIT_BRANCH/$LATEST_DIR/$OUTPUT_NAME.vsix
 
+                        echo "# Build date: $(date +%F-%T)" >> $OUTPUT_DIR/$BUILD_INFO
                         echo "build_info.url=$BUILD_URL" >> $BUILD_INFO
                         SHA1=$(sha1sum ${OUTPUT_NAME}.vsix | cut -d ' ' -f 1)
                         echo "build_info.SHA-1=${SHA1}" >> $BUILD_INFO

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ spec:
                         cp $OUTPUT_NAME-*.vsix $OUTPUT_NAME.vsix
                         scp $OUTPUT_NAME.vsix $sshHost:$deployParentDir/$GIT_BRANCH/$LATEST_DIR/$OUTPUT_NAME.vsix
 
-                        echo "# Build date: $(date +%F-%T)" >> $OUTPUT_DIR/$BUILD_INFO
+                        echo "# Build date: $(date +%F-%T)" >> $BUILD_INFO
                         echo "build_info.url=$BUILD_URL" >> $BUILD_INFO
                         SHA1=$(sha1sum ${OUTPUT_NAME}.vsix | cut -d ' ' -f 1)
                         echo "build_info.SHA-1=${SHA1}" >> $BUILD_INFO


### PR DESCRIPTION
Build date information in 'build_info.properties' would be useful to clarify the correct latest build - the largest build id does not always mean the latest build.

fixes eclipse/codewind#89