### PR TITLE
[33] Use showOpenDialog instead of quick pick, for OpenAPI files

### DIFF
--- a/dev/src/commands/AbstractGenerateStubCommand.ts
+++ b/dev/src/commands/AbstractGenerateStubCommand.ts
@@ -64,7 +64,7 @@ export default abstract class AbstractGenerateStubCommand extends AbstractGenera
             }
             // scan the project for OpenAPI definitions
             if (this.projectName !== "") {
-                await this.gatherOpenApiDefinitions();
+                await this.promptForOpenApiDefinition();
                 if (this.projectLanguage === "" || this.projectLanguage === "unknown") { // If project language is still not determined, we must prompt the user
                     var langTypeMap = Constants.ALL_CLIENT_LANGUAGES;
                     if (this._generatorType === "server") {

--- a/dev/src/commands/HtmlDocsCommand.ts
+++ b/dev/src/commands/HtmlDocsCommand.ts
@@ -40,7 +40,7 @@ export default class HtmlDocsCommand extends AbstractGenerateCommand {
             }
             // scan the project for OpenAPI definitions
             if (this.projectName !== "") {
-                await this.gatherOpenApiDefinitions();
+                await this.promptForOpenApiDefinition();
                 await this.getOutputLocation();
                 await this.callGenerator();
             }

--- a/dev/src/constants/Strings.json
+++ b/dev/src/constants/Strings.json
@@ -14,7 +14,11 @@
         "promptToPullImage": "The docker image, openapi-generator-cli, needs to be pulled from dockerhub. Continue?",
         "pullingImage": "Pulling image",
         "generatorRunning": "Generator running",
-        "errorNoDefinitions": "There are no OpenAPI definitions in the project.  Copy or import an OpenAPI definition into the project."
+        "errorNotADefinition": "The selected file {0}, based on its name, is likely not an OpenAPI document.  Choose another file.",
+        "promptForDefinition": "Select Definition",
+        "errorSelectOnlyFromProject": "Select an OpenAPI definition from the chosen project {0}",
+        "errorSelectFolderFromProject": "Select the target output folder from the chosen project {0}",
+        "openApiFilter": "OpenAPI Files"
     },
     "codeGen": {
         "success": "The {0} stub generated successfully",


### PR DESCRIPTION
Change from quick pick to open dialog for choosing OpenAPI definition

Fixes #33 

Signed-off-by: Keith Chong <kchong@ca.ibm.com>