### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Where to report issues?"
+about: File issues in the main Eclipse Codewind repository at https://github.com/eclipse/codewind/issues
+title: Issues need to be filed in the main Eclipse Codewind repository
+labels: ''
+assignees: ''
+
+---
+
+## Where to report issues?
+
+This repository is not used for issue tracking of the OpenAPI Tools Codewind extension for VSCode.
+
+🚨 Please don't submit new issues here. 🚨
+
+All issues for the Codewind plugin for VSCode are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues).


### PR DESCRIPTION
Add issue template to instruct user to open issues agains the main Codewind repo.