### PR TITLE
[2312] [OpenAPI] Bump up version numbers for 0.10.0

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "codewind-openapi-tools",
-	"version": "0.8.0",
+	"version": "0.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,7 @@
 	"name": "codewind-openapi-tools",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.8.0",
+	"version": "0.10.0",
 	"publisher": "IBM",
 	"engines": {
 		"vscode": "^1.33.0"


### PR DESCRIPTION
Fixes for VSCode extension - https://github.com/eclipse/codewind/issues/2312

Signed-off-by: Keith Chong <kchong@ca.ibm.com>