### PR TITLE
Remove Preview Label

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -15,7 +15,6 @@
 		"type": "git",
 		"url": "https://github.com/eclipse/codewind-openapi-vscode"
 	},
-	"preview": true,
 	"icon": "res/img/braces256px.png",
 	"categories": [
 		"Other"


### PR DESCRIPTION
No Bug- remove preview label to match Codewind for VS Code

Signed-off-by: Keith Chong <kchong@ca.ibm.com>